### PR TITLE
Fix html export with ep_headings2

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 const eejs = require('ep_etherpad-lite/node/eejs/');
 const Changeset = require('ep_etherpad-lite/static/js/Changeset');
-const Security = require('ep_etherpad-lite/static/js/security');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
@@ -34,9 +33,22 @@ const _analyzeLine = (alineAttrs, apool) => {
 exports.getLineHTMLForExport = async (hookName, context) => {
   const align = _analyzeLine(context.attribLine, context.apool);
   if (align) {
-    context.lineContent =
-      `<p style='text-align:${align}'>${Security.escapeHTML(context.text.substring(1))}</p>`;
-    return `<p style='text-align:${align}'>${Security.escapeHTML(context.text.substring(1))}</p>`;
+    if (context.text.indexOf('*') === 0) {
+      context.lineContent = context.lineContent.replace('*', '');
+    }
+    const heading = context.lineContent.match(/<h([1-6])([^>]+)?>/);
+
+    if (heading) {
+      if (heading.indexOf('style=') === -1) {
+        context.lineContent = context.lineContent.replace('>', ` style='text-align:${align}'>`);
+      } else {
+        context.lineContent = context.lineContent.replace('style=', `style='text-align:${align} `);
+      }
+    } else {
+      context.lineContent =
+        `<p style='text-align:${align}'>${context.lineContent}</p>`;
+    }
+    return context.lineContent;
   }
 };
 

--- a/static/tests/backend/specs/exportHTML.js
+++ b/static/tests/backend/specs/exportHTML.js
@@ -112,7 +112,7 @@ describe('export alignment to HTML', function () {
             const html = res.body.data.html;
             const expectedHTML =
               '<p style=\'text-align:right\'>Hello world</p><br><br></body></html>';
-            if (html.indexOf(expectedHTML) === -1) throw new Error('No center tag detected');
+            if (html.indexOf(expectedHTML) === -1) throw new Error('No right tag detected');
           })
           .end(done);
     });
@@ -135,9 +135,40 @@ describe('export alignment to HTML', function () {
             const html = res.body.data.html;
             const expectedHTML =
               '<p style=\'text-align:left\'>Hello world</p><br><br></body></html>';
-            if (html.indexOf(expectedHTML) === -1) throw new Error('No center tag detected');
+            if (html.indexOf(expectedHTML) === -1) throw new Error('No left tag detected');
           })
           .end(done);
+    });
+  });
+
+  context('when pad text is heading', function () {
+    before(async function () {
+      html = () => buildHTML('<h1><left>Hello world</left></h1>');
+    });
+
+    it('returns ok', function (done) {
+      api.get(getHTMLEndPointFor(padID))
+          .expect('Content-Type', /json/)
+          .expect(200, done);
+    });
+
+    it('returns HTML with Subscript HTML tags', function (done) {
+      try {
+        require.resolve('ep_headings2'); // eslint-disable-line
+        api.get(getHTMLEndPointFor(padID))
+            .expect((res) => {
+              const html = res.body.data.html;
+              const expectedHTML =
+                '<h1 style=\'text-align:left\'>Hello world</h1><br><br></body></html>';
+              if (html.indexOf(expectedHTML) === -1) throw new Error('No left tag detected');
+            })
+            .end(done);
+      } catch (e) {
+        if (e.message.indexOf('Cannot find module') === -1) {
+          throw new Error(e.message);
+        }
+        done();
+      }
     });
   });
 });


### PR DESCRIPTION
When using together with ep_headings2 the ep_headings currently replace existing text formatting, but this fix together with ep_headings2 fix will allow headings to be aligned with valid HTML.