### PR TITLE
Fix headings alignment

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,6 +2,7 @@
   "parts": [
     {
       "name": "main",
+      "post": ["ep_headings2/main"],
       "client_hooks": {
         "aceEditEvent": "ep_align/static/js/index",
         "postToolbarInit": "ep_align/static/js/index",

--- a/static/tests/frontend/specs/atest.js
+++ b/static/tests/frontend/specs/atest.js
@@ -148,4 +148,40 @@ describe('Alignment of Text', function () {
 
     done();
   });
+
+  it('works with headings', async function () {
+    // skip this test in case ep_headings2 isn't installed
+    if (!helper.padChrome$.window.clientVars.plugins.plugins.ep_headings2) this.skip();
+
+    const alignment = 'center';
+    const inner$ = helper.padInner$;
+    const chrome$ = helper.padChrome$;
+
+    // get the first text element out of the inner iframe
+    const $firstTextElement = inner$('div').first();
+
+    // select this text element
+    $firstTextElement.sendkeys('{selectall}');
+
+    // make it a heading
+    chrome$('#heading-selection').val('0');
+    chrome$('#heading-selection').change();
+
+    // get the center button and click it
+    const $button = chrome$('.ep_align_center');
+    $button.click();
+
+    // ace creates a new dom element when you press a button
+    // so just get the first text element again
+    const $newFirstTextElement = inner$('div').first().first();
+    const $alignedSpanStyles = $newFirstTextElement.children().first().attr('style');
+
+    await helper.waitForPromise(() => {
+      const alignmentExpr = `text-align: ?${alignment}`;
+      return $alignedSpanStyles.search(alignmentExpr) !== -1;
+    });
+
+    // make sure the text hasn't changed
+    expect($newFirstTextElement.text()).to.eql($firstTextElement.text());
+  });
 });


### PR DESCRIPTION
adds test coverage for aligning headings.

Ensures ep_headings2 is called before ep_align. In case ep_headings2 isn't installed, the additional post declaration in ep.json seems to be ignored (there is no dependency on ep_headings2).