### PR TITLE
Fix backend tests to resolve the error `ensure "done()" is called`

### DIFF
--- a/static/tests/backend/specs/exportHTML.ts
+++ b/static/tests/backend/specs/exportHTML.ts
@@ -170,8 +170,8 @@ describe('export alignment to HTML', function () {
                     reject(err);
                   } else {
                     const html = res.body.data.html;
-                    const expectedHTML = '<h1 style=\'text-align:left\'>Hello world</h1><br><br></body></html>';
-                    if (html.indexOf(expectedHTML) === -1) {
+                    const expectedHTML = /<h1 +style='text-align:left'>Hello world<\/h1><br><br><\/body><\/html>/;
+                    if (html.search(expectedHTML) === -1) {
                       reject(new Error('No left tag detected'));
                     } else {
                       resolve();

--- a/static/tests/backend/specs/exportHTML.ts
+++ b/static/tests/backend/specs/exportHTML.ts
@@ -136,7 +136,7 @@ describe('export alignment to HTML', function () {
         .expect(200);
     });
 
-    it('returns HTML with Subscript HTML tags', async function (done) {
+    it('returns HTML with Subscript HTML tags', async function () {
       const res = await agent.get(getHTMLEndPointFor(padID))
         .set("Authorization", await generateJWTToken())
       const html = res.body.data.html;


### PR DESCRIPTION
The [backend test of etherpad-lite](https://github.com/ether/etherpad-lite/actions/runs/9175232874/job/25234196727?pr=6396#step:13:1728) was outputting the following error:

```
 1) export alignment to HTML
       when pad text is left aligned
         returns HTML with Subscript HTML tags:
     Error: Timeout of 120000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/ep_align/static/tests/backend/specs/exportHTML.ts)
      at listOnTimeout (node:internal/timers:573:17)
      at process.processTimers (node:internal/timers:514:7)
```

The test (`when pad text is left aligned` - `returns HTML with Subscript HTML tags`) defined `done` as an argument even though it does not call `done`, and removing it seemed to resolve this error.
(The other `returns HTML with Subscript HTML tags` tests also do not define `done` as an argument.)