### PR TITLE
Preserve alignment when pressing Enter to split a line

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -11,7 +11,8 @@
         "aceInitialized": "ep_align/static/js/index",
         "aceAttribsToClasses": "ep_align/static/js/index",
         "collectContentPre": "ep_align/static/js/shared",
-        "aceRegisterBlockElements": "ep_align/static/js/index"
+        "aceRegisterBlockElements": "ep_align/static/js/index",
+        "aceRegisterLineAttributes": "ep_align/static/js/index"
       },
       "hooks": {
         "eejsBlock_editbarMenuLeft": "ep_align/index",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -9,6 +9,7 @@ const range = (start, end) => Array.from(
 );
 
 exports.aceRegisterBlockElements = () => tags;
+exports.aceRegisterLineAttributes = () => ['align'];
 
 // Bind the event handler to the toolbar buttons
 exports.postAceInit = (hookName, context) => {


### PR DESCRIPTION
## Summary

Registers `align` as a line attribute via the new `aceRegisterLineAttributes` hook (ether/etherpad-lite#7509), so alignment is preserved when pressing Enter:

- Enter at middle/end of aligned line: new line inherits alignment
- Enter at start of aligned line: alignment moves down with the text

Backwards compatible — the hook is ignored on Etherpad versions without it.

## Test plan

- [ ] Align a line to center, press Enter at end — new line should also be centered
- [ ] Align a line to right, move caret to start, press Enter — empty line above should be left-aligned, text moves down still right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)