### PR TITLE
Fix crash when settings.toolbar is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,11 @@ const settings = require('ep_etherpad-lite/node/utils/Settings');
 exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
   if (args.renderContext.isReadOnly) return cb();
 
-  for (const button of ['alignLeft', 'alignJustify', 'alignCenter', 'alignRight']) {
-    if (JSON.stringify(settings.toolbar).indexOf(button) > -1) {
-      return cb();
+  if (settings.toolbar) {
+    for (const button of ['alignLeft', 'alignJustify', 'alignCenter', 'alignRight']) {
+      if (JSON.stringify(settings.toolbar).indexOf(button) > -1) {
+        return cb();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the same bug as ether/ep_font_color#113 — `JSON.stringify(settings.toolbar)` throws when toolbar is not configured in settings.json. Adds a null check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)