### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_align
+# Text Alignment for Etherpad
 
 Adds text alignment buttons (left, center, justify, right) to the Etherpad toolbar, with HTML export support.
 


### PR DESCRIPTION
Replace the placeholder `ep_align` heading in README.md with "Text Alignment for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.