### PR TITLE
chore: modernize docs, a11y, and adopt template helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Agent Guide — ep_align
+
+Plugin that adds left/center/right/justify alignment buttons to the Etherpad editor toolbar, plus HTML export support for the four alignments.
+
+## Tech stack
+
+* Etherpad plugin framework (hooks declared in `ep.json`)
+* EJS templates rendered server-side via `eejsBlock_*` hooks
+* html10n for i18n (`locales/<lang>.json`, `data-l10n-id` in templates)
+* `ep_plugin_helpers` for shared boilerplate
+
+## Project structure
+
+```
+ep_align/
+├── ep.json                                  # hook declarations
+├── index.js                                 # server hooks
+├── static/
+│   ├── js/
+│   │   ├── index.js                         # client hooks
+│   │   └── shared.js                        # collectContent (shared client+server)
+│   └── tests/
+│       ├── backend/specs/exportHTML.ts      # Mocha export test
+│       └── frontend-new/specs/align.spec.ts # Playwright UI test
+├── templates/editbarButtons.ejs             # toolbar HTML
+├── locales/<lang>.json                      # i18n strings (en.json is canonical)
+├── package.json
+├── CONTRIBUTING.md
+└── AGENTS.md                                # this file
+```
+
+## Helpers used
+
+* **`template` from `ep_plugin_helpers`** — renders `eejsBlock_editbarMenuLeft`. Passes the hook `args` to its `skip` callback so the read-only and toolbar-conflict checks both run there.
+
+## Helpers NOT used (and why)
+
+These are documented gaps, not omissions:
+
+* **`lineAttribute`** — would replace `aceAttribsToClasses`, `aceDomLineProcessLineAttributes`, `aceRegisterBlockElements`, `aceRegisterLineAttributes`, and the `collectContentPre`/`Post` pair. The helper produces an unstyled `<{tag}>` wrapper; `ep_align` currently emits `<{tag} style="...;text-align:{tag}">`. Adopting the helper requires moving styling into a CSS file injected via `aceEditorCSS` and updating the Playwright assertion. Tracked as a follow-up.
+* **`lineAttributeExport`** — produces `<{tag}>...</{tag}>`. The backend export spec enforces `<p style='text-align:{tag}'>...</p>` for back-compat with consumers of the HTML export API. Adopting requires either extending the helper with a `wrapInP`-style option or breaking export compatibility.
+
+## Running tests locally
+
+`ep_align` runs inside Etherpad's test harness. From an etherpad checkout that has installed this plugin via `pnpm run plugins i --path ../ep_align`:
+
+```bash
+# Backend (Mocha) — harness boots its own server
+pnpm --filter ep_etherpad-lite run test
+
+# Playwright — needs `pnpm run dev` in a second terminal
+pnpm --filter ep_etherpad-lite run test-ui
+```
+
+## Standing rules for agent edits
+
+* PRs target `main`. Linear commits, no merge commits.
+* Every bug fix includes a regression test in the same commit.
+* All user-facing strings in `locales/`. No hardcoded English in templates.
+* No hardcoded `aria-label` on icon-only controls — etherpad's html10n auto-populates `aria-label` from the localized string when (a) the element has a `data-l10n-id` and (b) no author-supplied `aria-label` is present. Adding a hardcoded English `aria-label` blocks that and leaves it untranslated. (See `etherpad-lite/src/static/js/vendors/html10n.ts:665-678`.)
+* No nested interactive elements (no `<button>` inside `<a>`).
+* Never break the export shape (`<p style='text-align:X'>...</p>`) without updating `static/tests/backend/specs/exportHTML.ts` to match the new contract.
+* LLM/Agent contributions are explicitly welcomed by maintainers.
+
+## Quick reference: hooks declared in `ep.json`
+
+* Server: `eejsBlock_editbarMenuLeft`, `padInitToolbar`, `getLineHTMLForExport`, `collectContentPre`, `collectContentPost`
+* Client: `aceEditEvent`, `postToolbarInit`, `aceDomLineProcessLineAttributes`, `postAceInit`, `aceInitialized`, `aceAttribsToClasses`, `aceRegisterBlockElements`, `aceRegisterLineAttributes`, `collectContentPre` (shared.js)
+
+When adding a hook, register it in both `ep.json` *and* the matching `exports.<hook> = ...` in the JS file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,133 +1,74 @@
-# Contributor Guidelines
-(Please talk to people on the mailing list before you change this page, see our section on [how to get in touch](https://github.com/ether/etherpad-lite#get-in-touch))
+# Contributing to ep_align
 
-## Pull requests
+Thanks for helping improve `ep_align` — the alignment plugin for [Etherpad](https://etherpad.org/). LLM/Agent contributions are explicitly welcome, provided they follow the rules below.
 
-* the commit series in the PR should be _linear_ (it **should not contain merge commits**). This is necessary because we want to be able to [bisect](https://en.wikipedia.org/wiki/Bisection_(software_engineering)) bugs easily. Rewrite history/perform a rebase if necessary
-* PRs should be issued against the **develop** branch: we never pull directly into **master**
-* PRs **should not have conflicts** with develop. If there are, please resolve them rebasing and force-pushing
-* when preparing your PR, please make sure that you have included the relevant **changes to the documentation** (preferably with usage examples)
-* contain meaningful and detailed **commit messages** in the form:
-  ```
-  submodule: description
+For shared rules that apply to all Etherpad code (linear commits, deprecation policy, feature flags, stability guarantees), please read [ether/etherpad's CONTRIBUTING.md](https://github.com/ether/etherpad/blob/develop/CONTRIBUTING.md). This document only covers what's specific to plugin work.
 
-  longer description of the change you have made, eventually mentioning the
-  number of the issue that is being fixed, in the form: Fixes #someIssueNumber
-  ```
-* if the PR is a **bug fix**:
-  * the first commit in the series must be a test that shows the failure
-  * subsequent commits will fix the bug and make the test pass
-  * the final commit message should include the text `Fixes: #xxx` to link it to its bug report
-* think about stability: code has to be backwards compatible as much as possible. Always **assume your code will be run with an older version of the DB/config file**
-* if you want to remove a feature, **deprecate it instead**:
-  * write an issue with your deprecation plan
-  * output a `WARN` in the log informing that the feature is going to be removed
-  * remove the feature in the next version
-* if you want to add a new feature, put it under a **feature flag**:
-  * once the new feature has reached a minimal level of stability, do a PR for it, so it can be integrated early
-  * expose a mechanism for enabling/disabling the feature
-  * the new feature should be **disabled** by default. With the feature disabled, the code path should be exactly the same as before your contribution. This is a __necessary condition__ for early integration
-* think of the PR not as something that __you wrote__, but as something that __someone else is going to read__. The commit series in the PR should tell a novice developer the story of your thoughts when developing it
+## Plugin-specific rules
 
-## How to write a bug report
+* **Target branch:** PRs go to `main` on this repo. Plugin repos do not use git-flow's `develop` branch.
+* **Linear commits, no merge commits.** Rebase if needed.
+* **Every bug fix must include a regression test in the same commit.**
+* **Internationalization (i18n):** every user-facing string lives in `locales/<lang>.json` and is referenced via `data-l10n-id` in templates or `html10n.get(key)` in code. No hardcoded English in markup.
+* **Accessibility (a11y):** no nested interactive elements (no `<button>` inside `<a>`); every interactive control has an accessible name; keyboard focus order matches visual order. Note that on icon-only controls you should rely on Etherpad's html10n to populate `aria-label` from the `data-l10n-id` translation — adding a hardcoded English `aria-label` blocks that and leaves the control untranslated.
 
-* Please be polite, we all are humans and problems can occur.
-* Please add as much information as possible, for example
-  * client os(s) and version(s)
-    * browser(s) and version(s), is the problem reproducible on different clients
-    * special environments like firewalls or antivirus
-  * host os and version
-    * npm and nodejs version
-    * Logfiles if available
-  * steps to reproduce
-  * what you expected to happen
-  * what actually happened
-* Please format logfiles and code examples with markdown see github Markdown help below the issue textarea for more information.
+## Local development
 
-If you send logfiles, please set the loglevel switch DEBUG in your settings.json file:
+`ep_align` is a plugin, so you develop it inside a checkout of [ether/etherpad](https://github.com/ether/etherpad).
 
-```
-/* The log level we are using, can be: DEBUG, INFO, WARN, ERROR */
-  "loglevel": "DEBUG",
+```bash
+# Once: clone etherpad alongside this repo
+git clone https://github.com/ether/etherpad.git
+cd etherpad
+pnpm install
+
+# Install ep_align from your local clone
+pnpm run plugins i --path ../ep_align
+
+# Start the dev server (port 9001)
+pnpm --filter ep_etherpad-lite run dev
 ```
 
-The logfile location is defined in startup script or the log is directly shown in the commandline after you have started etherpad.
+Edits in `../ep_align/` are picked up after a server restart.
 
-## General goals of Etherpad
-To make sure everybody is going in the same direction:
-* easy to install for admins and easy to use for people
-* easy to integrate into other apps, but also usable as standalone
-* lightweight and scalable
-* extensible, as much functionality should be extendable with plugins so changes don't have to be done in core.
-Also, keep it maintainable. We don't wanna end up as the monster Etherpad was!
+## Tests
 
-## How to work with git?
-* Don't work in your master branch.
-* Make a new branch for every feature you're working on. (This ensures that you can work you can do lots of small, independent pull requests instead of one big one with complete different features)
-* Don't use the online edit function of github (this only creates ugly and not working commits!)
-* Try to make clean commits that are easy readable (including descriptive commit messages!)
-* Test before you push. Sounds easy, it isn't!
-* Don't check in stuff that gets generated during build or runtime
-* Make small pull requests that are easy to review but make sure they do add value by themselves / individually
+Tests live inside this repo and are executed by Etherpad's test harness:
+
+* Backend (Mocha): `static/tests/backend/specs/`
+* Playwright (frontend E2E): `static/tests/frontend-new/specs/`
+
+Run them from the etherpad checkout:
+
+```bash
+# Backend (no separate server needed, harness boots one)
+pnpm --filter ep_etherpad-lite run test
+
+# Playwright (requires `pnpm run dev` in another terminal)
+pnpm --filter ep_etherpad-lite run test-ui
+```
+
+Lint locally before pushing:
+
+```bash
+pnpm run lint
+```
 
 ## Coding style
-* Do write comments. (You don't have to comment every line, but if you come up with something that's a bit complex/weird, just leave a comment. Bear in mind that you will probably leave the project at some point and that other people will read your code. Undocumented huge amounts of code are worthless!)
-* Never ever use tabs
-* Indentation: JS/CSS: 2 spaces; HTML: 4 spaces
-* Don't overengineer. Don't try to solve any possible problem in one step, but try to solve problems as easy as possible and improve the solution over time!
-* Do generalize sooner or later! (if an old solution, quickly hacked together, poses more problems than it solves today, refactor it!)
-* Keep it compatible. Do not introduce changes to the public API, db schema or configurations too lightly. Don't make incompatible changes without good reasons!
-* If you do make changes, document them! (see below)
-* Use protocol independent urls "//"
 
-## Branching model / git workflow
-see git flow http://nvie.com/posts/a-successful-git-branching-model/
+* JS/CSS/HTML: 2 spaces, no tabs.
+* `pnpm run lint` must pass (configured via `eslint-config-etherpad`).
+* Avoid breaking changes to public hooks, the line-attribute storage shape, or HTML export output. The backend export spec enforces a stable shape.
 
-### `master` branch
-* the stable
-* This is the branch everyone should use for production stuff
+## Bug reports
 
-### `develop`branch
-* everything that is READY to go into master at some point in time
-* This stuff is tested and ready to go out
+Please include:
 
-### release branches
-* stuff that should go into master very soon
-* only bugfixes go into these (see http://nvie.com/posts/a-successful-git-branching-model/ for why)
-* we should not be blocking new features to develop, just because we feel that we should be releasing it to master soon. This is the situation that release branches solve/handle.
+* Etherpad version, ep_align version, browser + OS
+* Steps to reproduce
+* What you expected, what actually happened
+* Server log excerpt (set `"loglevel": "DEBUG"` in `settings.json` for verbose output)
 
-### hotfix branches
-* fixes for bugs in master
+## AI agents
 
-### feature branches (in your own repos)
-* these are the branches where you develop your features in
-* If it's ready to go out, it will be merged into develop
-
-Over the time we pull features from feature branches into the develop branch. Every month we pull from develop into master. Bugs in master get fixed in hotfix branches. These branches will get merged into master AND develop. There should never be commits in master that aren't in develop
-
-## Documentation
-The docs are in the `doc/` folder in the git repository, so people can easily find the suitable docs for the current git revision.
-
-Documentation should be kept up-to-date. This means, whenever you add a new API method, add a new hook or change the database model, pack the relevant changes to the docs in the same pull request.
-
-You can build the docs e.g. produce html, using `make docs`. At some point in the future we will provide an online documentation. The current documentation in the github wiki should always reflect the state of `master` (!), since there are no docs in master, yet.
-
-## Testing
-Front-end tests are found in the `tests/frontend/` folder in the repository. Run them by pointing your browser to `<yourdomainhere>/tests/frontend`.
-
-Back-end tests can be run from the `src` directory, via `npm test`.
-
-## Things you can help with
-Etherpad is much more than software.  So if you aren't a developer then worry not, there is still a LOT you can do!  A big part of what we do is community engagement.  You can help in the following ways
- * Triage bugs (applying labels) and confirming their existence
- * Testing fixes (simply applying them and seeing if it fixes your issue or not) - Some git experience required
- * Notifying large site admins of new releases
- * Writing Changelogs for releases
- * Creating Windows packages
- * Creating releases
- * Bumping dependencies periodically and checking they don't break anything
- * Write proposals for grants
- * Co-Author and Publish CVEs
- * Work with SFC to maintain legal side of project
- * Maintain TODO page - https://github.com/ether/etherpad-lite/wiki/TODO#IMPORTANT_TODOS
-
+If you are an LLM/agent contributor, also read [`AGENTS.md`](AGENTS.md) — it documents the file layout, helper usage, and standing rules for autonomous edits.

--- a/index.js
+++ b/index.js
@@ -1,23 +1,19 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
 const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
+const {template} = require('ep_plugin_helpers');
 
-exports.eejsBlock_editbarMenuLeft = (hookName, args, cb) => {
-  if (args.renderContext.isReadOnly) return cb();
+const TOOLBAR_BUTTONS = ['alignLeft', 'alignJustify', 'alignCenter', 'alignRight'];
 
-  if (settings.toolbar) {
-    for (const button of ['alignLeft', 'alignJustify', 'alignCenter', 'alignRight']) {
-      if (JSON.stringify(settings.toolbar).indexOf(button) > -1) {
-        return cb();
-      }
-    }
-  }
-
-  args.content += eejs.require('ep_align/templates/editbarButtons.ejs');
-  return cb();
-};
+exports.eejsBlock_editbarMenuLeft = template('ep_align/templates/editbarButtons.ejs', {
+  skip: (args) => {
+    if (args.renderContext.isReadOnly) return true;
+    if (!settings.toolbar) return false;
+    const serialized = JSON.stringify(settings.toolbar);
+    return TOOLBAR_BUTTONS.some((b) => serialized.indexOf(b) > -1);
+  },
+});
 
 const _analyzeLine = (alineAttrs, apool) => {
   let alignment = null;
@@ -31,7 +27,7 @@ const _analyzeLine = (alineAttrs, apool) => {
   return alignment;
 };
 
-// line, apool,attribLine,text
+// line, apool, attribLine, text
 exports.getLineHTMLForExport = async (hookName, context) => {
   const align = _analyzeLine(context.attribLine, context.apool);
   if (align) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "type": "individual",
     "url": "https://etherpad.org/"
   },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
+  },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.5.0
+        version: 0.5.1
     devDependencies:
       '@types/mocha':
         specifier: ^10.0.10
@@ -205,31 +209,37 @@ packages:
     resolution: {integrity: sha512-p+s/Wp8rf75Qqs2EPw4HC0xVLLW+/60MlVAsB7TYLoeg1e1CU/QCis36FxpziLS0ZY2+wXdTnPUxr+5kkThzwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-cZEL9jmZ2kAN53MEk+fFCRJM8pRwOEboDn7sTLjZW+hL6a0/8JNfHP20n8+MBDrhyD34BSF4A6wPCj/LNhtOIQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-linux-ppc64-gnu@1.3.0':
     resolution: {integrity: sha512-IOeRhcMXTNlk2oApsOozYVcOHu4t1EKYKnTz4huzdPyKNPX0Y9C7X8/6rk4aR3Inb5s4oVMT9IVKdgNXLcpGAQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-s390x-gnu@1.3.0':
     resolution: {integrity: sha512-op54XrlEbhgVRCxzF1pHFcLamdOmHDapwrqJ9xYRB7ZjwP/zQCKzz/uAsSaAlyQmbSi/PXV7lwfca4xkv860/Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-orbQF7sN02N/b9QF8Xp1RBO5YkfI+AYo9VZw0H2Gh4JYWSuiDHjOPEeFPDIRyWmXbQJuiVNSB+e1pZOjPPKIyg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-kpjqjIAC9MfsjmlgmgeC8U9gZi6g/HTuCqpI7SBMjsa7/9MvBaQ6TJ7dtnsV/+DXvfJ2+L5teBBXG+XxfpvIFA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-wasm32-wasi@1.3.0':
     resolution: {integrity: sha512-JAg0hY3kGsCPk7Jgh16yMTBZ6VEnoNR1DFZxiozjKwH+zSCfuDuM5S15gr50ofbwVw9drobIP2TTHdKZ15MJZQ==}
@@ -457,6 +467,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.5.1:
+    resolution: {integrity: sha512-Mnlz7LDdesOX3kINP7UrQXFH7CG+I7TLJzrcLukyuqd+sbveO/swCYPERSYDXUOWY3EfI8UZVRsTCNqA3+z6kA==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1911,6 +1925,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.5.1: {}
 
   es-abstract@1.24.2:
     dependencies:

--- a/static/tests/frontend-new/specs/align.spec.ts
+++ b/static/tests/frontend-new/specs/align.spec.ts
@@ -31,6 +31,25 @@ test.describe('Alignment of Text', () => {
     });
   }
 
+  test('toolbar buttons have no <button> nested inside <a>', async ({page}) => {
+    const padBody = await getPadBody(page);
+    await padBody.click();
+    // Run on the page (toolbar) frame, not the inner pad frame.
+    const offenders = await page.locator('.ep_align a button').count();
+    expect(offenders).toBe(0);
+    // Each align <a> exposes the click target with an accessible name.
+    // aria-label is populated by html10n at runtime (no author-supplied
+    // value — see html10n.ts:665-678) and tagged with
+    // data-l10n-aria-label="true" once it has run, so wait for that
+    // marker before asserting the localized aria-label is non-empty.
+    for (const dir of ['left', 'center', 'right', 'justify'] as const) {
+      const a = page.locator(`a.ep_align_${dir}`);
+      await expect(a).toHaveAttribute('role', 'button');
+      await expect(a).toHaveAttribute('data-l10n-aria-label', 'true');
+      await expect(a).toHaveAttribute('aria-label', /.+/);
+    }
+  });
+
   // The legacy `it('works with headings', ...)` test is intentionally
   // omitted: it required runtime detection of ep_headings2 being installed
   // (`helper.padChrome$.window.clientVars.plugins.plugins.ep_headings2`),

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,25 +1,33 @@
 <li class="separator acl-write"></li>
 
 <li data-type="button" data-key="alignLeft" data-l10n-id="ep_align.toolbar.left.title">
-  <a class="grouped-left ep_align" data-align="0" data-l10n-id="ep_align.toolbar.left.title" title="Align Left" aria-label="Align Left">
-    <button class="buttonicon buttonicon-align-left ep_align_left" data-align="0" aria-label="Align Left"></button>
-  </a>
+  <a class="grouped-left ep_align buttonicon buttonicon-align-left ep_align_left"
+     role="button" tabindex="0"
+     data-align="0"
+     data-l10n-id="ep_align.toolbar.left.title"
+     title="Align Left"></a>
 </li>
 
 <li data-type="button" data-key="alignCenter" data-l10n-id="ep_align.toolbar.center.title">
-  <a class="grouped-middle ep_align" data-align="1" data-l10n-id="ep_align.toolbar.center.title" title="Align Center" aria-label="Align Center">
-    <button class="buttonicon buttonicon-align-center ep_align_center" data-align="1" aria-label="Align Center"></button>
- </a>
+  <a class="grouped-middle ep_align buttonicon buttonicon-align-center ep_align_center"
+     role="button" tabindex="0"
+     data-align="1"
+     data-l10n-id="ep_align.toolbar.center.title"
+     title="Align Center"></a>
 </li>
 
 <li data-type="button" data-key="alignRight" data-l10n-id="ep_align.toolbar.right.title">
-  <a class="grouped-middle ep_align" data-align="3" data-l10n-id="ep_align.toolbar.right.title" title="Align Right" aria-label="Align Right">
-    <button class="buttonicon buttonicon-align-right ep_align_right" data-align="3" aria-label="Align Right"></button>
-  </a>
+  <a class="grouped-middle ep_align buttonicon buttonicon-align-right ep_align_right"
+     role="button" tabindex="0"
+     data-align="3"
+     data-l10n-id="ep_align.toolbar.right.title"
+     title="Align Right"></a>
 </li>
 
 <li data-type="button" data-key="alignJustify" data-l10n-id="ep_align.toolbar.justify.title">
-  <a class="grouped-right ep_align" data-align="2" data-l10n-id="ep_align.toolbar.justify.title" title="Align Justify" aria-label="Align Justify">
-    <button class="buttonicon buttonicon-align-justify ep_align_justify" data-align="2" aria-label="Align Justify"></button>
-  </a>
+  <a class="grouped-right ep_align buttonicon buttonicon-align-justify ep_align_justify"
+     role="button" tabindex="0"
+     data-align="2"
+     data-l10n-id="ep_align.toolbar.justify.title"
+     title="Align Justify"></a>
 </li>


### PR DESCRIPTION
## Summary

Pilot for a fleet-wide plugin modernization sweep. Lands five focused commits in `ep_align`:

- Rewrite `CONTRIBUTING.md` for plugin scope (target branch `main`, plugin install via `pnpm run plugins i --path`, i18n + a11y are now standing requirements).
- Add `AGENTS.md` modeled on `etherpad-lite/AGENTS.MD` — project structure, helpers used vs skipped (with reasons), test commands, standing rules.
- Flatten `templates/editbarButtons.ejs`: remove the `<button>` nested inside `<a>` (invalid HTML, screen-reader confusion), promote the `<a>` to the click target with `role="button"` and `tabindex="0"`. Remove the hardcoded `aria-label="Align Left/..."` so etherpad's html10n auto-populates `aria-label` from the localized string and tags it with `data-l10n-aria-label="true"` (see `etherpad-lite/src/static/js/vendors/html10n.ts:665-678`). Adds a Playwright assertion that locks in the structural fix.
- Add `ep_plugin_helpers ^0.5.0` to `dependencies`.
- Adopt `template` helper from `ep_plugin_helpers` for `eejsBlock_editbarMenuLeft`. The helper wraps `skip()` in a try/catch so a transient `settings.toolbar=undefined` no longer risks crashing pad render.

## Out of scope (documented gaps in `AGENTS.md`)

- `lineAttribute` helper adoption — would require migrating from inline `style="text-align:..."` rendering to a CSS file injected via `aceEditorCSS`, plus updating the Playwright assertion. Tracked as a follow-up.
- `lineAttributeExport` helper — backend export shape (`<p style='text-align:X'>...</p>`) is enforced by `static/tests/backend/specs/exportHTML.ts` for back-compat; helper produces a different shape.

## Test plan

- [ ] Backend: `static/tests/backend/specs/exportHTML.ts` (4 alignment cases + heading interaction)
- [ ] Frontend: `static/tests/frontend-new/specs/align.spec.ts` (4 alignment cases via toolbar click + new structural assertion)
- [ ] Lint passes

Local verification was hampered by my etherpad-lite checkout being on a feature branch with degraded test state — CI is the gate.