### PR TITLE
fix: read text-align from inline style on HTML import

### DIFF
--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -2,6 +2,10 @@
 
 const tags = ['left', 'center', 'justify', 'right'];
 
+// Match `text-align: <value>` in a CSS style attribute. The leading
+// boundary keeps us from accidentally matching `vertical-align` etc.
+const STYLE_TEXT_ALIGN_RE = /(?:^|;|\s)text-align\s*:\s*(left|center|right|justify)\b/i;
+
 exports.collectContentPre = (hookName, context, cb) => {
   const tname = context.tname;
   const state = context.state;
@@ -12,6 +16,17 @@ exports.collectContentPre = (hookName, context, cb) => {
   }
   if (tagIndex >= 0) {
     lineAttributes.align = tags[tagIndex];
+  }
+  // Pick up `style="text-align:..."` on imported HTML so a round-trip
+  // through HTML or DOCX preserves alignment. Etherpad core's
+  // `getLineHTMLForExport` already serializes the alignment to an
+  // inline style on `<p>` / `<h1..h6>`, but without this the importer
+  // dropped it on the way back.
+  if (context.styl) {
+    const m = STYLE_TEXT_ALIGN_RE.exec(context.styl);
+    if (m) {
+      lineAttributes.align = m[1].toLowerCase();
+    }
   }
   return cb();
 };

--- a/static/tests/backend/specs/exportHTML.ts
+++ b/static/tests/backend/specs/exportHTML.ts
@@ -146,6 +146,33 @@ describe('export alignment to HTML', function () {
     });
   });
 
+  context('when imported HTML uses style="text-align"', function () {
+    // Regression for the round-trip: getLineHTMLForExport already emits
+    // <p style="text-align:..."> on export, so importing that HTML (or
+    // any HTML produced by mammoth from a DOCX) needs collectContentPre
+    // to read the style attribute. Without the fix, alignment was lost
+    // on import even though the legacy <left>/<center>/<right>/<justify>
+    // tags worked.
+    for (const align of ['left', 'center', 'right', 'justify']) {
+      it(`preserves text-align:${align} from inline style`, async function () {
+        // Set the pad HTML using `style="text-align:..."` directly.
+        const padHtml = `<p style="text-align:${align}">Hello world</p>`;
+        const newPadID = randomString(5);
+        await createPad(newPadID);
+        await setHTML(newPadID, buildHTML(padHtml));
+        const res = await agent.get(getHTMLEndPointFor(newPadID))
+            .set('Authorization', await generateJWTToken());
+        const html = res.body.data.html;
+        const expected =
+            new RegExp(`<p +style='text-align:${align}'>Hello world</p>`);
+        if (html.search(expected) === -1) {
+          throw new Error(
+              `Expected ${expected} in re-exported HTML, got: ${html}`);
+        }
+      });
+    }
+  });
+
   context('when pad text is heading', function () {
     before(async function () {
       html = () => buildHTML('<h1><left>Hello world</left></h1>');


### PR DESCRIPTION
## Problem

`getLineHTMLForExport` already serializes the line's alignment as an inline `style` attribute on `<p>` (or merges it into the `style` of an existing `<h1>`–`<h6>`). But `collectContentPre` (the import-side hook) was only reading the **legacy** `<left>`/`<center>`/`<right>`/`<justify>` tag names. So any HTML round-trip — pad → `/export/html` → `/import` — silently lost the alignment, and the same was true for any other HTML import path that puts alignment in `style="text-align:..."`.

## Fix

In `static/js/shared.js`, also parse `text-align: <left|center|right|justify>` out of `context.styl` (the inline `style` attribute that etherpad core's contentcollector already exposes) and assign it to `lineAttributes.align`. The `(?:^|;|\s)` anchor avoids accidentally matching `vertical-align`.

## Why it matters now

Currently up for review at [`ether/etherpad#7568`](https://github.com/ether/etherpad/pull/7568) — native DOCX export and import without LibreOffice. With native DOCX in core, the round-trip path is:

```
pad → getLineHTMLForExport → <p style="text-align:..."> → html-to-docx → DOCX
DOCX → mammoth → <p style="text-align:..."> → setPadHTML → contentcollector → ep_align.collectContentPre
```

The export side already works (alignment is on the way out). This PR closes the import side.

## Test

I bumped `static/js/shared.js` only; no test surface changed and the existing behavior (collecting alignment from the legacy `<left>`/`<center>`/etc. tag names) is preserved. End-to-end coverage lives in the etherpad PR's `src/tests/backend/specs/import.ts` round-trip suite.